### PR TITLE
Filter responses via hallucination detector

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -528,6 +528,12 @@ def process_user_message(user_message, theme=None):
             
             # Post-traitement de la réponse
             cleaned_response = utils.clean_model_output(response)
+            cleaned_response = post_process_answer(
+                cleaned_response,
+                relevant_docs,
+                detected_lang,
+                question=cleaned_message
+            )
             
             # Vérification de la qualité
             if len(cleaned_response) < config.MIN_RESPONSE_LENGTH:


### PR DESCRIPTION
## Summary
- ensure answers go through the hallucination post-processing step

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_683f15ca8d608325b059ef6bb74873d6