### PR TITLE
Add benchmark web app skeleton

### DIFF
--- a/benchmark-app/README.md
+++ b/benchmark-app/README.md
@@ -1,0 +1,26 @@
+# AI Tools Benchmark Web App
+
+This sample application demonstrates a simple benchmarking dashboard for various AI tools using a Node.js backend with a Postgres database and a React frontend.
+
+## Setup
+
+1. **Install dependencies**
+   ```bash
+   cd benchmark-app/server
+   npm install
+   ```
+
+2. **Create the database**
+   ```bash
+   createdb benchmarkdb
+   psql benchmarkdb -f ../sql/init.sql
+   ```
+
+3. **Run the server**
+   ```bash
+   node index.js
+   ```
+
+The server runs on `http://localhost:3001` and serves the React client.
+
+Open `http://localhost:3001` in your browser to view the benchmark table.

--- a/benchmark-app/client/app.js
+++ b/benchmark-app/client/app.js
@@ -1,0 +1,40 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [benchmarks, setBenchmarks] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/benchmarks')
+      .then(res => res.json())
+      .then(setBenchmarks)
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h1>AI Tools Benchmark (2024 - Present)</h1>
+      <table border="1" cellPadding="5">
+        <thead>
+          <tr>
+            <th>Year</th>
+            <th>Tool</th>
+            <th>Category</th>
+            <th>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {benchmarks.map(row => (
+            <tr key={row.id}>
+              <td>{row.year}</td>
+              <td>{row.tool}</td>
+              <td>{row.category}</td>
+              <td>{row.score}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/benchmark-app/client/index.html
+++ b/benchmark-app/client/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>AI Tools Benchmark</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/benchmark-app/server/db.js
+++ b/benchmark-app/server/db.js
@@ -1,0 +1,9 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || 'postgres://localhost/benchmarkdb'
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params)
+};

--- a/benchmark-app/server/index.js
+++ b/benchmark-app/server/index.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+const db = require('./db');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/benchmarks', async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM benchmarks ORDER BY year DESC, id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch data' });
+  }
+});
+
+app.use(express.static(path.join(__dirname, '../client')));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '../client/index.html'));
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/benchmark-app/server/package.json
+++ b/benchmark-app/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "benchmark-server",
+  "version": "1.0.0",
+  "description": "API server for AI benchmark app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "pg": "^8.11.5"
+  }
+}

--- a/benchmark-app/sql/init.sql
+++ b/benchmark-app/sql/init.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS benchmarks (
+  id SERIAL PRIMARY KEY,
+  year INT NOT NULL,
+  tool TEXT NOT NULL,
+  category TEXT NOT NULL,
+  score NUMERIC NOT NULL
+);
+
+INSERT INTO benchmarks (year, tool, category, score) VALUES
+(2024, 'ChatGPT', 'development', 8.5),
+(2024, 'Claude', 'database', 7.2),
+(2024, 'Gemini', 'problem_solving', 8.8),
+(2025, 'ChatGPT', 'database', 7.9);


### PR DESCRIPTION
## Summary
- add minimal benchmark app with Node.js server, React client
- document how to run the app and initialize sample DB

## Testing
- `node benchmark-app/server/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686cf25663a48325a125fb6c5590ad94